### PR TITLE
fix "make serve" for ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 ruby '>=2.5.8'
 
 gem 'github-pages', group: :jekyll_plugins
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
When attempting to run `make serve` on a machine running ruby >v3.0 and jekyll 3.9.0, an error is raised (see below).

For more detail on this issue, see: https://github.com/jekyll/jekyll/issues/8523. 

Adding `webrick` as a new dependency in the Gemfile fixes the build error.

```
> make serve

...

bundler: failed to load command: jekyll (/usr/local/lib/ruby/gems/3.0.0/bin/jekyll)
/usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:184:in `require_relative'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:184:in `setup'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:102:in `process'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `block in start'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `each'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `start'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
        from /usr/local/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        from /usr/local/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        from /usr/local/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        from /usr/local/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        from /usr/local/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        from /usr/local/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/exe/jekyll:15:in `<top (required)>'
        from /usr/local/lib/ruby/gems/3.0.0/bin/jekyll:23:in `load'
        from /usr/local/lib/ruby/gems/3.0.0/bin/jekyll:23:in `<top (required)>'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:474:in `exec'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/exe/bundle:49:in `block in <top (required)>'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/3.0.0/bundler/friendly_errors.rb:128:in `with_friendly_errors'
        from /usr/local/Cellar/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/exe/bundle:37:in `<top (required)>'
        from /Users/tompollard/.gem/ruby/2.6.0/bin/bundle:23:in `load'
        from /Users/tompollard/.gem/ruby/2.6.0/bin/bundle:23:in `<main>'
make: *** [serve] Error 1
```