### PR TITLE
Add mathjax support for math formula

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,6 +99,8 @@ exclude:
 # Turn on built-in syntax highlighting.
 highlighter: rouge
 
+# Render math
+math: true
 
 # Remote theme
 remote_theme: carpentries/carpentries-theme

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -1,0 +1,21 @@
+{% comment %}
+  JavaScript used in lesson and workshop pages.
+{% endcomment %}
+<script src="{{ relative_root_path }}/assets/js/jquery.min.js"></script>
+<script src="{{ relative_root_path }}/assets/js/bootstrap.min.js"></script>
+<script src="{{ relative_root_path }}/assets/js/lesson.js"></script>
+{% if site.math %}
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        extensions: ["tex2jax.js"],
+        jax: ["input/TeX", "output/HTML-CSS"],
+        tex2jax: {
+          inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+          displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+          processEscapes: true
+        },
+        "HTML-CSS": { fonts: ["TeX"] }
+      });
+    </script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+{% endif %}


### PR DESCRIPTION
Currently, math formula added to page content in latex are not properly rendered. For example, adding $$y = \frac{1}{2}$$ to an `_episodes` file will be rendered as:

![Screen Shot 2021-10-11 at 03 34 44](https://user-images.githubusercontent.com/822601/136750454-b647958b-7c81-4d22-9fef-619938661ac6.png)

This pull request adds mathjax support for rendering math. After the change, the same chunk will be rendered as:

![Screen Shot 2021-10-11 at 03 34 03](https://user-images.githubusercontent.com/822601/136750459-1a39a61f-74f3-4a96-b2e0-0d6639884dca.png)

